### PR TITLE
Update weather icon URLs to new path

### DIFF
--- a/src/OpenWeatherMapSharp/Models/WeatherRoot.cs
+++ b/src/OpenWeatherMapSharp/Models/WeatherRoot.cs
@@ -116,21 +116,21 @@ namespace OpenWeatherMapSharp.Models
         /// </summary>
         [JsonIgnore]
         public string Icon 
-            => $"https://openweathermap.org/img/w/{WeatherInfos?[0]?.Icon}.png";
+            => $"https://openweathermap.org/img/wn/{WeatherInfos?[0]?.Icon}.png";
 
         /// <summary>
         /// Weather icon URL (2x resolution).
         /// </summary>
         [JsonIgnore]
         public string Icon2x 
-            => $"https://openweathermap.org/img/w/{WeatherInfos?[0]?.Icon}@2x.png";
+            => $"https://openweathermap.org/img/wn/{WeatherInfos?[0]?.Icon}@2x.png";
 
         /// <summary>
         /// Weather icon URL (4x resolution).
         /// </summary>
         [JsonIgnore]
         public string Icon4x 
-            => $"https://openweathermap.org/img/w/{WeatherInfos?[0]?.Icon}@4x.png";
+            => $"https://openweathermap.org/img/wn/{WeatherInfos?[0]?.Icon}@4x.png";
 
         /// <summary>
         /// Weather icon name.

--- a/src/OpenWeatherMapSharp/OpenWeatherMapSharp.csproj
+++ b/src/OpenWeatherMapSharp/OpenWeatherMapSharp.csproj
@@ -4,7 +4,7 @@
 		<TargetFramework>netstandard2.0</TargetFramework>
 		<GeneratePackageOnBuild>True</GeneratePackageOnBuild>
 		<Title>OpenWeatherMapSharp</Title>
-		<Version>4.0.0</Version>
+		<Version>4.0.1</Version>
 		<Authors>Thomas Sebastian Jensen</Authors>
 		<Company>tsjdev-apps.de</Company>
 		<Description>An unofficial .NET API wrapper for OpenWeatherMap.org</Description>
@@ -15,9 +15,7 @@
 		<PackageIcon>icon.png</PackageIcon>
 		<PackageTags>OpenWeatherMap; Api; Mock; Wrapper; free; Weather</PackageTags>
 		<PackageReleaseNotes>
-			- Add Air Pollution endpoints
-			- Update NuGet packages
-			- Code improvements
+			- Fix icon urls
 		</PackageReleaseNotes>
 		<NeutralLanguage>en</NeutralLanguage>
 		<PackageReadmeFile>README.md</PackageReadmeFile>


### PR DESCRIPTION
Changed weather icon URL paths from '/img/w/' to '/img/wn/' to reflect OpenWeatherMap's updated icon hosting structure. This ensures correct icon display for all resolutions.
This pull request includes updates to fix incorrect weather icon URLs and increment the package version. The most important changes involve modifying the `WeatherRoot` class to use the correct base URL for weather icons and updating the project metadata to reflect the changes.

### Fixes to weather icon URLs:
* [`src/OpenWeatherMapSharp/Models/WeatherRoot.cs`](diffhunk://#diff-3a3ce0060656fba89e14f41a693507795fd3eada17931282f6275f3bc57a3c4dL119-R133): Updated the `Icon`, `Icon2x`, and `Icon4x` properties to use the correct base URL (`https://openweathermap.org/img/wn/`) for weather icons. This ensures compatibility with OpenWeatherMap's updated URL structure.

### Updates to project metadata:
* [`src/OpenWeatherMapSharp/OpenWeatherMapSharp.csproj`](diffhunk://#diff-c3f68e7db44a7071b2179bffffd7aa7d1d630c7dc168812cb0cc4fce32fd960aL7-R7): Incremented the package version from `4.0.0` to `4.0.1` to reflect the bug fix.
* [`src/OpenWeatherMapSharp/OpenWeatherMapSharp.csproj`](diffhunk://#diff-c3f68e7db44a7071b2179bffffd7aa7d1d630c7dc168812cb0cc4fce32fd960aL18-R18): Updated the `PackageReleaseNotes` to include "Fix icon urls" as the description of changes in this release.