### PR TITLE
Add weather icon URL properties to ForecastItem

### DIFF
--- a/src/OpenWeatherMapSharp/Models/ForecastItem.cs
+++ b/src/OpenWeatherMapSharp/Models/ForecastItem.cs
@@ -82,5 +82,33 @@ namespace OpenWeatherMapSharp.Models
         [JsonIgnore]
         public DateTime Date 
             => DateUnix.ToDateTime();
+
+        /// <summary>
+        /// Weather icon URL (default size).
+        /// </summary>
+        [JsonIgnore]
+        public string Icon
+            => $"https://openweathermap.org/img/wn/{WeatherInfos?[0]?.Icon}.png";
+
+        /// <summary>
+        /// Weather icon URL (2x resolution).
+        /// </summary>
+        [JsonIgnore]
+        public string Icon2x
+            => $"https://openweathermap.org/img/wn/{WeatherInfos?[0]?.Icon}@2x.png";
+
+        /// <summary>
+        /// Weather icon URL (4x resolution).
+        /// </summary>
+        [JsonIgnore]
+        public string Icon4x
+            => $"https://openweathermap.org/img/wn/{WeatherInfos?[0]?.Icon}@4x.png";
+
+        /// <summary>
+        /// Weather icon name.
+        /// </summary>
+        [JsonIgnore]
+        public string IconName
+            => WeatherInfos?[0]?.Icon;
     }
 }

--- a/src/OpenWeatherMapSharp/OpenWeatherMapSharp.csproj
+++ b/src/OpenWeatherMapSharp/OpenWeatherMapSharp.csproj
@@ -4,7 +4,7 @@
 		<TargetFramework>netstandard2.0</TargetFramework>
 		<GeneratePackageOnBuild>True</GeneratePackageOnBuild>
 		<Title>OpenWeatherMapSharp</Title>
-		<Version>4.0.1</Version>
+		<Version>4.1.0</Version>
 		<Authors>Thomas Sebastian Jensen</Authors>
 		<Company>tsjdev-apps.de</Company>
 		<Description>An unofficial .NET API wrapper for OpenWeatherMap.org</Description>
@@ -15,7 +15,7 @@
 		<PackageIcon>icon.png</PackageIcon>
 		<PackageTags>OpenWeatherMap; Api; Mock; Wrapper; free; Weather</PackageTags>
 		<PackageReleaseNotes>
-			- Fix icon urls
+			- Add icon urls to ForecastItem
 		</PackageReleaseNotes>
 		<NeutralLanguage>en</NeutralLanguage>
 		<PackageReadmeFile>README.md</PackageReadmeFile>


### PR DESCRIPTION
Introduced Icon, Icon2x, Icon4x, and IconName properties to provide easy access to weather icon URLs and icon name based on the first WeatherInfo entry. These properties are marked with [JsonIgnore] to avoid serialization.
This pull request introduces enhancements to the `ForecastItem` model in the `OpenWeatherMapSharp` library and updates the project metadata to reflect these changes. The most notable additions are new properties for weather icon URLs at various resolutions and the weather icon name.

### Enhancements to `ForecastItem` model:

* [`src/OpenWeatherMapSharp/Models/ForecastItem.cs`](diffhunk://#diff-84eff098f5659dc4e4e93879cce182891e1ceb1aa1133eff2a09cf875598b6d9R85-R112): Added new properties to provide weather icon URLs (`Icon`, `Icon2x`, `Icon4x`) and the weather icon name (`IconName`). These properties are marked with `[JsonIgnore]` to exclude them from JSON serialization.

### Project metadata updates:

* [`src/OpenWeatherMapSharp/OpenWeatherMapSharp.csproj`](diffhunk://#diff-c3f68e7db44a7071b2179bffffd7aa7d1d630c7dc168812cb0cc4fce32fd960aL7-R7): Updated the project version from `4.0.1` to `4.1.0` to reflect the new features.
* [`src/OpenWeatherMapSharp/OpenWeatherMapSharp.csproj`](diffhunk://#diff-c3f68e7db44a7071b2179bffffd7aa7d1d630c7dc168812cb0cc4fce32fd960aL18-R18): Modified the release notes to document the addition of icon URLs to `ForecastItem`.