### PR TITLE
Rename AirPolution* to AirPollution* for consistency

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,21 +94,21 @@ Task<OpenWeatherMapServiceResponse<List<GeocodeInfo>>> GetLocationByLatLonAsync(
 /// <summary>
 /// Retrieves current air pollution data for a specific location.
 /// </summary>
-Task<OpenWeatherMapServiceResponse<AirPolutionRoot>> GetAirPolutionAsync(
+Task<OpenWeatherMapServiceResponse<AirPollutionRoot>> GetAirPollutionAsync(
     double latitude,
     double longitude);
 
 /// <summary>
 /// Retrieves forecasted air pollution data for the coming days for a specific location.
 /// </summary>
-Task<OpenWeatherMapServiceResponse<AirPolutionRoot>> GetAirPolutionForecastAsync(
+Task<OpenWeatherMapServiceResponse<AirPollutionRoot>> GetAirPollutionForecastAsync(
     double latitude,
     double longitude);
 
 /// <summary>
 /// Retrieves historical air pollution data for a specific location and time range.
 /// </summary>
-Task<OpenWeatherMapServiceResponse<AirPolutionRoot>> GetAirPolutionHistoryAsync(
+Task<OpenWeatherMapServiceResponse<AirPollutionRoot>> GetAirPollutionHistoryAsync(
     double latitude,
     double longitude,
     DateTime start,

--- a/samples/OpenWeatherMapSharp.Console/OpenWeatherMapSharp.Console.csproj
+++ b/samples/OpenWeatherMapSharp.Console/OpenWeatherMapSharp.Console.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/samples/OpenWeatherMapSharp.Console/OpenWeatherMapSharp.Console.csproj
+++ b/samples/OpenWeatherMapSharp.Console/OpenWeatherMapSharp.Console.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Spectre.Console" Version="0.50.0" />
+    <PackageReference Include="Spectre.Console" Version="0.54.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/OpenWeatherMapSharp.Console/Program.cs
+++ b/samples/OpenWeatherMapSharp.Console/Program.cs
@@ -88,16 +88,16 @@ Panel weatherPanel = new(new Rows(weatherMarkupList))
 AnsiConsole.Write(weatherPanel);
 
 // == AIR POLLUTION ==
-OpenWeatherMapServiceResponse<AirPolutionRoot> airPollutionResponse
-    = await openWeatherMapService.GetAirPolutionAsync(geolocation.Latitude, geolocation.Longitude);
+OpenWeatherMapServiceResponse<AirPollutionRoot> airPollutionResponse
+    = await openWeatherMapService.GetAirPollutionAsync(geolocation.Latitude, geolocation.Longitude);
 
-if (!airPollutionResponse.IsSuccess || airPollutionResponse.Response is not AirPolutionRoot airQuality || airQuality.Entries.Count == 0)
+if (!airPollutionResponse.IsSuccess || airPollutionResponse.Response is not AirPollutionRoot airQuality || airQuality.Entries.Count == 0)
 {
     AnsiConsole.MarkupLine("[bold red]Unfortunately I can't retrieve air pollution data. Please try again.[/]");
     return;
 }
 
-AirPolutionEntry pollution = airQuality.Entries.First();
+AirPollutionEntry pollution = airQuality.Entries.First();
 
 // Map AQI to meaning
 string GetAqiMeaning(int aqi) => aqi switch

--- a/src/OpenWeatherMapSharp/IOpenWeatherMapService.cs
+++ b/src/OpenWeatherMapSharp/IOpenWeatherMapService.cs
@@ -128,7 +128,7 @@ namespace OpenWeatherMapSharp
         /// <param name="latitude">Latitude of the location.</param>
         /// <param name="longitude">Longitude of the location.</param>
         /// <returns>Current air pollution data wrapped in a service response.</returns>
-        Task<OpenWeatherMapServiceResponse<AirPolutionRoot>> GetAirPolutionAsync(
+        Task<OpenWeatherMapServiceResponse<AirPollutionRoot>> GetAirPollutionAsync(
             double latitude,
             double longitude);
 
@@ -138,7 +138,7 @@ namespace OpenWeatherMapSharp
         /// <param name="latitude">Latitude of the location.</param>
         /// <param name="longitude">Longitude of the location.</param>
         /// <returns>Air pollution forecast data wrapped in a service response.</returns>
-        Task<OpenWeatherMapServiceResponse<AirPolutionRoot>> GetAirPolutionForecastAsync(
+        Task<OpenWeatherMapServiceResponse<AirPollutionRoot>> GetAirPollutionForecastAsync(
             double latitude,
             double longitude);
 
@@ -150,7 +150,7 @@ namespace OpenWeatherMapSharp
         /// <param name="start">Start of the time range (UTC).</param>
         /// <param name="end">End of the time range (UTC).</param>
         /// <returns>Historical air pollution data wrapped in a service response.</returns>
-        Task<OpenWeatherMapServiceResponse<AirPolutionRoot>> GetAirPolutionHistoryAsync(
+        Task<OpenWeatherMapServiceResponse<AirPollutionRoot>> GetAirPollutionHistoryAsync(
             double latitude,
             double longitude,
             DateTime start,

--- a/src/OpenWeatherMapSharp/Models/AirPollutionComponents.cs
+++ b/src/OpenWeatherMapSharp/Models/AirPollutionComponents.cs
@@ -6,7 +6,7 @@ namespace OpenWeatherMapSharp.Models
     /// Represents the concentration values 
     /// of various air pollutants (in μg/m³).
     /// </summary>
-    public class AirPolutionComponents
+    public class AirPollutionComponents
     {
         /// <summary>
         /// Carbon monoxide concentration.

--- a/src/OpenWeatherMapSharp/Models/AirPollutionEntry.cs
+++ b/src/OpenWeatherMapSharp/Models/AirPollutionEntry.cs
@@ -8,19 +8,19 @@ namespace OpenWeatherMapSharp.Models
     /// Represents a single entry of air quality data, 
     /// including AQI, components, and timestamp.
     /// </summary>
-    public class AirPolutionEntry
+    public class AirPollutionEntry
     {
         /// <summary>
         /// Main air quality index (AQI).
         /// </summary>
         [JsonPropertyName("main")]
-        public AirPolutionIndex AQI { get; set; }
+        public AirPollutionIndex AQI { get; set; }
 
         /// <summary>
         /// Concentrations of individual air components.
         /// </summary>
         [JsonPropertyName("components")]
-        public AirPolutionComponents Components { get; set; }
+        public AirPollutionComponents Components { get; set; }
 
         /// <summary>
         /// Timestamp of the measurement (Unix time in seconds).

--- a/src/OpenWeatherMapSharp/Models/AirPollutionIndex.cs
+++ b/src/OpenWeatherMapSharp/Models/AirPollutionIndex.cs
@@ -5,7 +5,7 @@ namespace OpenWeatherMapSharp.Models
     /// <summary>
     /// Represents the air quality index (AQI) value.
     /// </summary>
-    public class AirPolutionIndex
+    public class AirPollutionIndex
     {
         /// <summary>
         /// Air Quality Index (1 = Good, 5 = Very Poor).

--- a/src/OpenWeatherMapSharp/Models/AirPollutionRoot.cs
+++ b/src/OpenWeatherMapSharp/Models/AirPollutionRoot.cs
@@ -6,7 +6,7 @@ namespace OpenWeatherMapSharp.Models
     /// <summary>
     /// Root object representing the air quality response from the API.
     /// </summary>
-    public class AirPolutionRoot
+    public class AirPollutionRoot
     {
         /// <summary>
         /// Geographic coordinates of the measurement location.
@@ -18,6 +18,6 @@ namespace OpenWeatherMapSharp.Models
         /// List of air polution measurements.
         /// </summary>
         [JsonPropertyName("list")]
-        public List<AirPolutionEntry> Entries { get; set; }
+        public List<AirPollutionEntry> Entries { get; set; }
     }
 }

--- a/src/OpenWeatherMapSharp/OpenWeatherMapService.cs
+++ b/src/OpenWeatherMapSharp/OpenWeatherMapService.cs
@@ -150,24 +150,24 @@ namespace OpenWeatherMapSharp
         }
 
         /// <inheritdoc/>
-        public async Task<OpenWeatherMapServiceResponse<AirPolutionRoot>> GetAirPolutionAsync(double latitude, double longitude)
+        public async Task<OpenWeatherMapServiceResponse<AirPollutionRoot>> GetAirPollutionAsync(double latitude, double longitude)
         {
             string url = string.Format(Statics.AirPollutionCoordinatesUri, latitude, longitude, _apiKey);
-            return await HttpService.GetDataAsync<AirPolutionRoot>(url);
+            return await HttpService.GetDataAsync<AirPollutionRoot>(url);
         }
 
         /// <inheritdoc/>
-        public async Task<OpenWeatherMapServiceResponse<AirPolutionRoot>> GetAirPolutionForecastAsync(double latitude, double longitude)
+        public async Task<OpenWeatherMapServiceResponse<AirPollutionRoot>> GetAirPollutionForecastAsync(double latitude, double longitude)
         {
             string url = string.Format(Statics.AirPollutionCoordinatesForecastUri, latitude, longitude, _apiKey);
-            return await HttpService.GetDataAsync<AirPolutionRoot>(url);
+            return await HttpService.GetDataAsync<AirPollutionRoot>(url);
         }
 
         /// <inheritdoc/>
-        public async Task<OpenWeatherMapServiceResponse<AirPolutionRoot>> GetAirPolutionHistoryAsync(double latitude, double longitude, DateTime start, DateTime end)
+        public async Task<OpenWeatherMapServiceResponse<AirPollutionRoot>> GetAirPollutionHistoryAsync(double latitude, double longitude, DateTime start, DateTime end)
         {
             string url = string.Format(Statics.AirPollutionCoordinatesHistoryUri, latitude, longitude, start.ToUnixTimestamp(), end.ToUnixTimestamp(), _apiKey);
-            return await HttpService.GetDataAsync<AirPolutionRoot>(url);
+            return await HttpService.GetDataAsync<AirPollutionRoot>(url);
         }
     }
 }

--- a/src/OpenWeatherMapSharp/OpenWeatherMapSharp.csproj
+++ b/src/OpenWeatherMapSharp/OpenWeatherMapSharp.csproj
@@ -4,7 +4,7 @@
 		<TargetFramework>netstandard2.0</TargetFramework>
 		<GeneratePackageOnBuild>True</GeneratePackageOnBuild>
 		<Title>OpenWeatherMapSharp</Title>
-		<Version>4.1.0</Version>
+		<Version>4.2.0</Version>
 		<Authors>Thomas Sebastian Jensen</Authors>
 		<Company>tsjdev-apps.de</Company>
 		<Description>An unofficial .NET API wrapper for OpenWeatherMap.org</Description>
@@ -15,7 +15,7 @@
 		<PackageIcon>icon.png</PackageIcon>
 		<PackageTags>OpenWeatherMap; Api; Mock; Wrapper; free; Weather</PackageTags>
 		<PackageReleaseNotes>
-			- Add icon urls to ForecastItem
+			- Fix typos in Pollution API
 		</PackageReleaseNotes>
 		<NeutralLanguage>en</NeutralLanguage>
 		<PackageReadmeFile>README.md</PackageReadmeFile>

--- a/src/OpenWeatherMapSharp/OpenWeatherMapSharp.csproj
+++ b/src/OpenWeatherMapSharp/OpenWeatherMapSharp.csproj
@@ -27,7 +27,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="System.Text.Json" Version="9.0.7" />
+		<PackageReference Include="System.Text.Json" Version="10.0.0" />
 	</ItemGroup>
 
 </Project>

--- a/tests/OpenWeatherMapSharp.UnitTests/OpenWeatherMapServiceTests.cs
+++ b/tests/OpenWeatherMapSharp.UnitTests/OpenWeatherMapServiceTests.cs
@@ -275,8 +275,8 @@ public class OpenWeatherMapServiceTests
         double longitude = 8.69;
 
         // Act
-        OpenWeatherMapServiceResponse<AirPolutionRoot> response =
-            await service.GetAirPolutionAsync(latitude, longitude);
+        OpenWeatherMapServiceResponse<AirPollutionRoot> response =
+            await service.GetAirPollutionAsync(latitude, longitude);
 
         // Assert
         Assert.NotNull(response);
@@ -298,8 +298,8 @@ public class OpenWeatherMapServiceTests
         double longitude = 8.69;
 
         // Act
-        OpenWeatherMapServiceResponse<AirPolutionRoot> response =
-            await service.GetAirPolutionForecastAsync(latitude, longitude);
+        OpenWeatherMapServiceResponse<AirPollutionRoot> response =
+            await service.GetAirPollutionForecastAsync(latitude, longitude);
 
         // Assert
         Assert.NotNull(response);
@@ -325,8 +325,8 @@ public class OpenWeatherMapServiceTests
         DateTime start = end.AddHours(-24);
 
         // Act
-        OpenWeatherMapServiceResponse<AirPolutionRoot> response =
-            await service.GetAirPolutionHistoryAsync(latitude, longitude, start, end);
+        OpenWeatherMapServiceResponse<AirPollutionRoot> response =
+            await service.GetAirPollutionHistoryAsync(latitude, longitude, start, end);
 
         // Assert
         Assert.NotNull(response);

--- a/tests/OpenWeatherMapSharp.UnitTests/OpenWeatherMapSharp.UnitTests.csproj
+++ b/tests/OpenWeatherMapSharp.UnitTests/OpenWeatherMapSharp.UnitTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 

--- a/tests/OpenWeatherMapSharp.UnitTests/OpenWeatherMapSharp.UnitTests.csproj
+++ b/tests/OpenWeatherMapSharp.UnitTests/OpenWeatherMapSharp.UnitTests.csproj
@@ -10,9 +10,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
     <PackageReference Include="xunit" Version="2.9.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.3">
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>


### PR DESCRIPTION
This pull request primarily fixes typos in the Pollution API by renaming all instances of "Polution" to the correct "Pollution" across the codebase, updates dependencies, and bumps the project version. These changes improve code clarity, maintainability, and ensure consistency throughout the API, documentation, and tests.

### Pollution API naming corrections

* Renamed all classes and identifiers from `AirPolution*` to `AirPollution*` (e.g., `AirPollutionRoot`, `AirPollutionEntry`, `AirPollutionComponents`, `AirPollutionIndex`) in the `OpenWeatherMapSharp.Models` namespace and associated files. [[1]](diffhunk://#diff-e0df41f402f013c8ef83a95a94e4717f59ba2629ccee36093345b4db22316f99L9-R9) [[2]](diffhunk://#diff-49e23d231034c6bf64528805108273666bfed13c31595429e8f7432e1a5075b0L11-R23) [[3]](diffhunk://#diff-28d31cf8cd87b30ce08b12adc96999c033957f154864e64a628cc1c6bc3648c2L8-R8) [[4]](diffhunk://#diff-bbdb07c2059d3e11a0703c6136a00b60c587293b8f12b11f5d2f6b5db95068d9L9-R9) [[5]](diffhunk://#diff-bbdb07c2059d3e11a0703c6136a00b60c587293b8f12b11f5d2f6b5db95068d9L21-R21)
* Updated all method names and usages from `GetAirPolution*` to `GetAirPollution*` in interfaces, implementations, and tests. [[1]](diffhunk://#diff-440e3d00a7ca4edf88d6fd6474e5df8b229872460600e623022ce46ab7bef452L131-R131) [[2]](diffhunk://#diff-440e3d00a7ca4edf88d6fd6474e5df8b229872460600e623022ce46ab7bef452L141-R141) [[3]](diffhunk://#diff-440e3d00a7ca4edf88d6fd6474e5df8b229872460600e623022ce46ab7bef452L153-R153) [[4]](diffhunk://#diff-f268d1876ec5d13f379dd36ef5b70b6f47e8f8f310e57c3cb28f764c516fb30aL153-R170) [[5]](diffhunk://#diff-b33f3f44842b0cd27151536e7a0fc369618dfde39d2774a476c09ee6b490b8e9L91-R100) [[6]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L97-R111) [[7]](diffhunk://#diff-b7661d50f7227a93f6bf7077d7f406e5e88178f35b32cb935ab43f55b2b90d15L278-R279) [[8]](diffhunk://#diff-b7661d50f7227a93f6bf7077d7f406e5e88178f35b32cb935ab43f55b2b90d15L301-R302) [[9]](diffhunk://#diff-b7661d50f7227a93f6bf7077d7f406e5e88178f35b32cb935ab43f55b2b90d15L328-R329)

### Dependency and framework updates

* Upgraded target frameworks for both the console sample and unit tests to `net10.0`. [[1]](diffhunk://#diff-abc8ce6abce162add4ce2132ca504148894324b318fbd60d0b692dbf867f80deL5-R11) [[2]](diffhunk://#diff-f04b9b2575c998a9d4783a876362e0d351edb8edcfb70d6ac9d2585058c954b2L4-R4)
* Updated package dependencies: `Spectre.Console` to `0.54.0`, `System.Text.Json` to `10.0.0`, and test packages (`Microsoft.NET.Test.Sdk` to `18.0.1`, `xunit.runner.visualstudio` to `3.1.5`). [[1]](diffhunk://#diff-abc8ce6abce162add4ce2132ca504148894324b318fbd60d0b692dbf867f80deL5-R11) [[2]](diffhunk://#diff-c3f68e7db44a7071b2179bffffd7aa7d1d630c7dc168812cb0cc4fce32fd960aL30-R30) [[3]](diffhunk://#diff-f04b9b2575c998a9d4783a876362e0d351edb8edcfb70d6ac9d2585058c954b2L13-R15)

### Project version and release notes

* Bumped library version to `4.2.0` and updated release notes to reflect the Pollution API typo fixes. [[1]](diffhunk://#diff-c3f68e7db44a7071b2179bffffd7aa7d1d630c7dc168812cb0cc4fce32fd960aL7-R7) [[2]](diffhunk://#diff-c3f68e7db44a7071b2179bffffd7aa7d1d630c7dc168812cb0cc4fce32fd960aL18-R18)